### PR TITLE
107M 永远亭前错误的ATS-SN地上速照地上子修正

### DIFF
--- a/GensokyoCircleLine/MapSignals107M.txt
+++ b/GensokyoCircleLine/MapSignals107M.txt
@@ -240,8 +240,7 @@ BveTs Map 2.00
 	Structure['ATS-S_L'].Put('1',0,0.05,0,,,,3,);
 10144+$dist1;
 	$sig=distance;
-	$sig-400;
-	Beacon.Put(9,0,400105);
+	Beacon.Put(9,0,105);
 	Structure['ATS-S_Speed'].Put('1',0,0.01,0,,,,3,);
 	Structure['ATS-S_Speed'].Put('1',0,0.01,-2,,,,3,);
 10599+$dist1;


### PR DESCRIPTION
107M 永远亭前错误的ATS-SN地上速照地上子修正

目前该任务默认指定车E127没有使用该功能（bve原版插件没有使用该速照，该速照为ask标准）
但为了确保后续兼容性进行更正。